### PR TITLE
Correct case of health check plugin

### DIFF
--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -46,7 +46,7 @@ const config: IImperativeConfig = {
             required: ["address"],
         },
     }],
-    pluginHealthCheck: __dirname + "/healthcheck.handler",
+    pluginHealthCheck: __dirname + "/healthCheck.handler",
 };
 
 export = config;


### PR DESCRIPTION
Correct the definition of the health check plugin to allow the plugin to be installed.

Signed-off-by: Andrew Smithson <smithson@uk.ibm.com>