### PR TITLE
Use ZosConnectSession in API classes

### DIFF
--- a/src/ZosConnectSession.ts
+++ b/src/ZosConnectSession.ts
@@ -1,0 +1,4 @@
+export class ZosConnectSession {
+    constructor(public address: string, public user?: string, public password?: string) {
+    }
+}

--- a/src/api/api/ZosConnectApi.ts
+++ b/src/api/api/ZosConnectApi.ts
@@ -1,5 +1,5 @@
-import { IProfile } from "@brightside/imperative";
 import { ConnectionUtil } from "../../connection";
+import { ZosConnectSession } from "../../ZosConnectSession";
 import { Api } from "./Api";
 
 export class ZosConnectApi {
@@ -9,8 +9,8 @@ export class ZosConnectApi {
      * @param profile The IProfile to use for connection information.
      * @param aarFile The AAR file to be installed.
      */
-    public static async install(profile: IProfile, aarFile: Buffer): Promise<Api> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async install(session: ZosConnectSession, aarFile: Buffer): Promise<Api> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const api = await zosConn.createApi(aarFile);
         return new Api(api.getApiName(), api.getVersion(), api.getDescription());
     }
@@ -20,8 +20,8 @@ export class ZosConnectApi {
      *
      * @param profile The IProfile to use for connection information.
      */
-    public static async list(profile: IProfile): Promise<Api[]> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async list(session: ZosConnectSession): Promise<Api[]> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const installedApis = await zosConn.getApis();
         const apis = [];
         for (const api of installedApis) {
@@ -37,8 +37,8 @@ export class ZosConnectApi {
      * @param apiName The name of the API to delete.
      * @param force Whether the API should be deleted regardless of status.
      */
-    public static async delete(profile: IProfile, apiName: string, force: boolean): Promise<void> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async delete(session: ZosConnectSession, apiName: string, force: boolean): Promise<void> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const api = await zosConn.getApi(apiName);
         if (force) {
             await api.stop();
@@ -53,21 +53,21 @@ export class ZosConnectApi {
      * @param apiName The name of the API to update.
      * @param aarFile The AAR file containing the updated API information.
      */
-    public static async update(profile: IProfile, apiName: string, aarFile: Buffer): Promise<Api> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async update(session: ZosConnectSession, apiName: string, aarFile: Buffer): Promise<Api> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const api = await zosConn.getApi(apiName);
         await api.update(aarFile);
         return new Api(api.getApiName(), api.getVersion(), api.getDescription());
     }
 
-    public static async start(profile: IProfile, apiName: string): Promise<void> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async start(session: ZosConnectSession, apiName: string): Promise<void> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const api = await zosConn.getApi(apiName);
         await api.start();
     }
 
-    public static async stop(profile: IProfile, apiName: string): Promise<void> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async stop(session: ZosConnectSession, apiName: string): Promise<void> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const api = await zosConn.getApi(apiName);
         await api.stop();
     }

--- a/src/api/apirequester/ZosConnectApiRequester.ts
+++ b/src/api/apirequester/ZosConnectApiRequester.ts
@@ -1,16 +1,16 @@
-import { IProfile } from "@brightside/imperative";
 import { ConnectionUtil } from "../../connection";
+import { ZosConnectSession } from "../../ZosConnectSession";
 import { ApiRequester } from "./ApiRequester";
 
 export class ZosConnectApiRequester {
-    public static async install(profile: IProfile, araFile: Buffer): Promise<ApiRequester> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async install(session: ZosConnectSession, araFile: Buffer): Promise<ApiRequester> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const apiRequester = await zosConn.createApiRequester(araFile);
         return new ApiRequester(apiRequester.getName(), apiRequester.getVersion(), apiRequester.getDescription());
     }
 
-    public static async list(profile: IProfile): Promise<ApiRequester[]> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async list(session: ZosConnectSession): Promise<ApiRequester[]> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const installedApiRequesters = await zosConn.getApiRequesters();
         const apiRequesters = [];
         for (const apiRequester of installedApiRequesters) {
@@ -20,8 +20,8 @@ export class ZosConnectApiRequester {
         return apiRequesters;
     }
 
-    public static async delete(profile: IProfile, apiRequesterName: string, force: boolean) {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async delete(session: ZosConnectSession, apiRequesterName: string, force: boolean) {
+        const zosConn = ConnectionUtil.getConnection(session);
         const apiRequester = await zosConn.getApiRequester(apiRequesterName);
         if (force) {
             await apiRequester.stop();
@@ -29,21 +29,22 @@ export class ZosConnectApiRequester {
         await apiRequester.delete();
     }
 
-    public static async update(profile: IProfile, apiRequesterName: string, araFile: Buffer): Promise<ApiRequester> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async update(session: ZosConnectSession, apiRequesterName: string,
+                               araFile: Buffer): Promise<ApiRequester> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const apiRequester = await zosConn.getApiRequester(apiRequesterName);
         await apiRequester.update(araFile);
         return new ApiRequester(apiRequester.getName(), apiRequester.getVersion(), apiRequester.getDescription());
     }
 
-    public static async start(profile: IProfile, apiRequsterName: string): Promise<void> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async start(session: ZosConnectSession, apiRequsterName: string): Promise<void> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const apiRequester = await zosConn.getApiRequester(apiRequsterName);
         await apiRequester.start();
     }
 
-    public static async stop(profile: IProfile, apiRequesterName: string): Promise<void> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async stop(session: ZosConnectSession, apiRequesterName: string): Promise<void> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const apiRequester = await zosConn.getApiRequester(apiRequesterName);
         await apiRequester.stop();
     }

--- a/src/api/service/ZosConnectService.ts
+++ b/src/api/service/ZosConnectService.ts
@@ -1,15 +1,15 @@
-import { IProfile } from "@brightside/imperative";
 import { ConnectionUtil } from "../../connection";
+import { ZosConnectSession } from "../../ZosConnectSession";
 import { Service } from "./Service";
 
 export class ZosConnectService {
     /**
      * Get a list of the Services installed in the server.
      *
-     * @param profile The IProfile to use for connection information.
+     * @param session The session to use for connection information.
      */
-    public static async list(profile: IProfile): Promise<Service[]> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async list(session: ZosConnectSession): Promise<Service[]> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const services = await zosConn.getServices();
         const resultsObj = [];
         for (const service of services) {
@@ -23,11 +23,11 @@ export class ZosConnectService {
     /**
      * Install a new service into the Server.
      *
-     * @param profile The IProfile to use for connection information.
+     * @param session The session to use for connection information.
      * @param sarFile The SAR file to install.
      */
-    public static async install(profile: IProfile, sarFile: Buffer): Promise<Service> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async install(session: ZosConnectSession, sarFile: Buffer): Promise<Service> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const service = await zosConn.createService(sarFile);
         return new Service(service.getName(), service.getDescription(), service.getServiceProvider());
     }
@@ -35,12 +35,12 @@ export class ZosConnectService {
     /**
      * Update the named Service.
      *
-     * @param profile The IProfile to use for connection information.
+     * @param session The Isession to use for connection information.
      * @param serviceName The name of the Service to update.
      * @param sarFile The SAR file containing the new Service information.
      */
-    public static async update(profile: IProfile, serviceName: string, sarFile: Buffer): Promise<Service> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async update(session: ZosConnectSession, serviceName: string, sarFile: Buffer): Promise<Service> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const service = await zosConn.getService(serviceName);
         await service.update(sarFile);
         return new Service(service.getName(), service.getDescription(), service.getServiceProvider());
@@ -49,12 +49,12 @@ export class ZosConnectService {
     /**
      * Delete the named Service from the server.
      *
-     * @param profile The IProfile to use for connection information.
+     * @param session The Isession to use for connection information.
      * @param serviceName The name of the Service to delete.
      * @param force Whether the Service should be deleted regardless of status.
      */
-    public static async delete(profile: IProfile, serviceName: string, force: boolean): Promise<void> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async delete(session: ZosConnectSession, serviceName: string, force: boolean): Promise<void> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const service = await zosConn.getService(serviceName);
         if (force) {
             await service.stop();
@@ -62,14 +62,14 @@ export class ZosConnectService {
         await service.delete();
     }
 
-    public static async start(profile: IProfile, serviceName: string): Promise<void> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async start(session: ZosConnectSession, serviceName: string): Promise<void> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const service = await zosConn.getService(serviceName);
         await service.start();
     }
 
-    public static async stop(profile: IProfile, serviceName: string): Promise<void> {
-        const zosConn = ConnectionUtil.getConnection(profile);
+    public static async stop(session: ZosConnectSession, serviceName: string): Promise<void> {
+        const zosConn = ConnectionUtil.getConnection(session);
         const service = await zosConn.getService(serviceName);
         await service.stop();
     }

--- a/src/cli/api/delete/delete.handler.ts
+++ b/src/cli/api/delete/delete.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApi } from "../../../api/api/ZosConnectApi";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiDeleteHandler implements ICommandHandler {
     public async process(commandParams: IHandlerParameters) {
         const profile = commandParams.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            await ZosConnectApi.delete(profile, commandParams.arguments.apiName, commandParams.arguments.force);
+            await ZosConnectApi.delete(session, commandParams.arguments.apiName, commandParams.arguments.force);
             commandParams.response.console.log("Successfully deleted API " + commandParams.arguments.apiName);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/api/install/install.handler.ts
+++ b/src/cli/api/install/install.handler.ts
@@ -2,6 +2,7 @@ import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import fs = require("fs");
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApi } from "../../../api/api/ZosConnectApi";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiInstallHandler implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters) {
@@ -9,9 +10,9 @@ export default class ApiInstallHandler implements ICommandHandler {
         const fileBuf = fs.readFileSync(filePath);
 
         const profile = commandParameters.profiles.get("zosconnect");
-
+        const session = ConnectionUtil.getSession(profile);
         try {
-            const api = await ZosConnectApi.install(profile, fileBuf);
+            const api = await ZosConnectApi.install(session, fileBuf);
             commandParameters.response.data.setObj(api);
             commandParameters.response.console.log("Successfully installed API " + api.name);
         } catch (error) {

--- a/src/cli/api/list/list.handler.ts
+++ b/src/cli/api/list/list.handler.ts
@@ -1,12 +1,16 @@
 import {ICommandHandler, IHandlerParameters} from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApi } from "../../../api/api/ZosConnectApi";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiListHandler implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters): Promise<void> {
+        // tslint:disable-next-line
+        console.log(commandParameters.arguments);
         const profile = commandParameters.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            const apis = await ZosConnectApi.list(profile);
+            const apis = await ZosConnectApi.list(session);
             for (const api of apis) {
                 commandParameters.response.console.log(`${api.name}(${api.version}) - ${api.description}`);
             }

--- a/src/cli/api/start/start.handler.ts
+++ b/src/cli/api/start/start.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApi } from "../../../api/api/ZosConnectApi";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiStartHandler implements ICommandHandler {
     public async process(commandParams: IHandlerParameters): Promise<void> {
         const profile = commandParams.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            await ZosConnectApi.start(profile, commandParams.arguments.apiName);
+            await ZosConnectApi.start(session, commandParams.arguments.apiName);
             commandParams.response.console.log(`Successfully started API ${commandParams.arguments.apiName}`);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/api/stop/stop.handler.ts
+++ b/src/cli/api/stop/stop.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApi } from "../../../api/api/ZosConnectApi";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiStartHandler implements ICommandHandler {
     public async process(commandParams: IHandlerParameters): Promise<void> {
         const profile = commandParams.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            await ZosConnectApi.stop(profile, commandParams.arguments.apiName);
+            await ZosConnectApi.stop(session, commandParams.arguments.apiName);
             commandParams.response.console.log(`Successfully started API ${commandParams.arguments.apiName}`);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/api/update/update.handler.ts
+++ b/src/cli/api/update/update.handler.ts
@@ -2,6 +2,7 @@ import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import fs = require("fs");
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApi } from "../../../api/api/ZosConnectApi";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiUpdateHander implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters) {
@@ -9,8 +10,9 @@ export default class ApiUpdateHander implements ICommandHandler {
         const fileBuf = fs.readFileSync(filePath);
 
         const profile = commandParameters.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            const api = await ZosConnectApi.update(profile, commandParameters.arguments.apiName, fileBuf);
+            const api = await ZosConnectApi.update(session, commandParameters.arguments.apiName, fileBuf);
             commandParameters.response.console.log("Successfully updated API " + api.name);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/apirequester/delete/delete.handler.ts
+++ b/src/cli/apirequester/delete/delete.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApiRequester } from "../../../api/apirequester/ZosConnectApiRequester";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiRequesterDeleteHandler implements ICommandHandler {
     public async process(commandParams: IHandlerParameters): Promise<void> {
         const profile = commandParams.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            await ZosConnectApiRequester.delete(profile, commandParams.arguments.apiRequesterName,
+            await ZosConnectApiRequester.delete(session, commandParams.arguments.apiRequesterName,
                 commandParams.arguments.force);
             commandParams.response.console.log(
                 `Successfully deleted API Requester ${commandParams.arguments.apiRequesterName}`);

--- a/src/cli/apirequester/install/install.handler.ts
+++ b/src/cli/apirequester/install/install.handler.ts
@@ -2,6 +2,7 @@ import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import fs = require("fs");
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApiRequester } from "../../../api/apirequester/ZosConnectApiRequester";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiRequsterInstallHandler implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters): Promise<void> {
@@ -9,9 +10,9 @@ export default class ApiRequsterInstallHandler implements ICommandHandler {
         const fileBuf = fs.readFileSync(filePath);
 
         const profile = commandParameters.profiles.get("zosconnect");
-
+        const session = ConnectionUtil.getSession(profile);
         try {
-            const apiRequester = await ZosConnectApiRequester.install(profile, fileBuf);
+            const apiRequester = await ZosConnectApiRequester.install(session, fileBuf);
             commandParameters.response.data.setObj(apiRequester);
             commandParameters.response.console.log(`Successfully installed API Requester ${apiRequester.name}`);
         } catch (error) {

--- a/src/cli/apirequester/list/list.handler.ts
+++ b/src/cli/apirequester/list/list.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApiRequester } from "../../../api/apirequester/ZosConnectApiRequester";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiRequesterListHandler implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters): Promise<void> {
         const profile = commandParameters.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            const apiRequesters = await ZosConnectApiRequester.list(profile);
+            const apiRequesters = await ZosConnectApiRequester.list(session);
             for (const apiRequester of apiRequesters) {
                 commandParameters.response.console.log(
                     `${apiRequester.name}(${apiRequester.version}) - ${apiRequester.description}`);

--- a/src/cli/apirequester/start/start.handler.ts
+++ b/src/cli/apirequester/start/start.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApiRequester } from "../../../api/apirequester/ZosConnectApiRequester";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiRequesterStartHandler implements ICommandHandler {
     public async process(commandParams: IHandlerParameters): Promise<void> {
         const profile = commandParams.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            await ZosConnectApiRequester.start(profile, commandParams.arguments.apiRequesterName);
+            await ZosConnectApiRequester.start(session, commandParams.arguments.apiRequesterName);
             commandParams.response.console.log(`Successfully started API ${commandParams.arguments.apiRequesterName}`);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/apirequester/stop/stop.handler.ts
+++ b/src/cli/apirequester/stop/stop.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApiRequester } from "../../../api/apirequester/ZosConnectApiRequester";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ServiceStartHandler implements ICommandHandler {
     public async process(commandParams: IHandlerParameters): Promise<void> {
         const profile = commandParams.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            await ZosConnectApiRequester.stop(profile, commandParams.arguments.apiRequesterName);
+            await ZosConnectApiRequester.stop(session, commandParams.arguments.apiRequesterName);
             commandParams.response.console.log(`Successfully started API ${commandParams.arguments.apiRequesterName}`);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/apirequester/update/update.handler.ts
+++ b/src/cli/apirequester/update/update.handler.ts
@@ -2,6 +2,7 @@ import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import fs = require("fs");
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectApiRequester } from "../../../api/apirequester/ZosConnectApiRequester";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ApiRequesterUpdateHander implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters) {
@@ -9,8 +10,9 @@ export default class ApiRequesterUpdateHander implements ICommandHandler {
         const fileBuf = fs.readFileSync(filePath);
 
         const profile = commandParameters.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            const apiRequester = await ZosConnectApiRequester.update(profile,
+            const apiRequester = await ZosConnectApiRequester.update(session,
                 commandParameters.arguments.apiRequesterName, fileBuf);
             commandParameters.response.console.log("Successfully updated API " + apiRequester.name);
         } catch (error) {

--- a/src/cli/service/delete/delete.handler.ts
+++ b/src/cli/service/delete/delete.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectService } from "../../../api/service/ZosConnectService";
+import { ConnectionUtil } from "../../../connection";
 
 export default class DeleteHandler implements ICommandHandler {
     public async process(commandParams: IHandlerParameters): Promise<void> {
         const profile = commandParams.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            await ZosConnectService.delete(profile, commandParams.arguments.serviceName, commandParams.arguments.force);
+            await ZosConnectService.delete(session, commandParams.arguments.serviceName, commandParams.arguments.force);
             commandParams.response.console.log(`Successfully deleted Service ${commandParams.arguments.serviceName}`);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/service/install/install.handler.ts
+++ b/src/cli/service/install/install.handler.ts
@@ -2,6 +2,7 @@ import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import fs = require("fs");
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectService } from "../../../api/service/ZosConnectService";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ServiceInstallHandler implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters): Promise<void> {
@@ -9,8 +10,9 @@ export default class ServiceInstallHandler implements ICommandHandler {
         const fileBuf = fs.readFileSync(filePath);
 
         const profile = commandParameters.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            const service = await ZosConnectService.install(profile, fileBuf);
+            const service = await ZosConnectService.install(session, fileBuf);
             commandParameters.response.data.setObj(service);
             commandParameters.response.console.log(`Successfully installed Service ${service.name}`);
         } catch (error) {

--- a/src/cli/service/list/list.handler.ts
+++ b/src/cli/service/list/list.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectService } from "../../../api/service/ZosConnectService";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ServiceListHandler implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters): Promise<void> {
         const profile = commandParameters.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            const services = await ZosConnectService.list(profile);
+            const services = await ZosConnectService.list(session);
             for (const service of services) {
                 commandParameters.response.console.log(`${service.name} - ${service.description} ` +
                     `[${service.serviceProvider}]`);

--- a/src/cli/service/start/start.handler.ts
+++ b/src/cli/service/start/start.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectService } from "../../../api/service/ZosConnectService";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ServiceStartHandler implements ICommandHandler {
     public async process(commandParams: IHandlerParameters): Promise<void> {
         const profile = commandParams.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            await ZosConnectService.start(profile, commandParams.arguments.serviceName);
+            await ZosConnectService.start(session, commandParams.arguments.serviceName);
             commandParams.response.console.log(`Successfully started API ${commandParams.arguments.serviceName}`);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/service/stop/stop.handler.ts
+++ b/src/cli/service/stop/stop.handler.ts
@@ -1,12 +1,14 @@
 import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectService } from "../../../api/service/ZosConnectService";
+import { ConnectionUtil } from "../../../connection";
 
 export default class ServiceStartHandler implements ICommandHandler {
     public async process(commandParams: IHandlerParameters): Promise<void> {
         const profile = commandParams.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            await ZosConnectService.stop(profile, commandParams.arguments.serviceName);
+            await ZosConnectService.stop(session, commandParams.arguments.serviceName);
             commandParams.response.console.log(`Successfully started API ${commandParams.arguments.serviceName}`);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/service/update/update.handler.ts
+++ b/src/cli/service/update/update.handler.ts
@@ -2,6 +2,7 @@ import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
 import fs = require("fs");
 import { RequestError, StatusCodeError } from "request-promise/errors";
 import { ZosConnectService } from "../../../api/service/ZosConnectService";
+import { ConnectionUtil } from "../../../connection";
 
 export default class UpdateHandler implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters): Promise<void> {
@@ -9,8 +10,9 @@ export default class UpdateHandler implements ICommandHandler {
         const fileBuf = fs.readFileSync(filePath);
 
         const profile = commandParameters.profiles.get("zosconnect");
+        const session = ConnectionUtil.getSession(profile);
         try {
-            const service = await ZosConnectService.update(profile, commandParameters.arguments.serviceName, fileBuf);
+            const service = await ZosConnectService.update(session, commandParameters.arguments.serviceName, fileBuf);
             commandParameters.response.console.log(`Successfully updated Service ${service.name}`);
         } catch (error) {
             switch (error.constructor) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,15 +1,20 @@
-import { IProfile } from "@brightside/imperative";
+import { IProfile, Session } from "@brightside/imperative";
 import { ZosConnect } from "@zosconnect/zosconnect-node";
 import request = require("request");
+import { ZosConnectSession } from "./ZosConnectSession";
 
 export class ConnectionUtil {
-    public static getConnection(profile: IProfile): ZosConnect {
+    public static getSession(profile: IProfile): ZosConnectSession {
+        return new ZosConnectSession(profile.address, profile.user, profile.password);
+    }
+
+    public static getConnection(session: ZosConnectSession): ZosConnect {
         const options = {} as request.OptionsWithUri;
-        options.uri = profile.address;
-        if (profile.user !== undefined) {
+        options.uri = session.address;
+        if (session.user !== undefined) {
             options.auth = {} as request.AuthOptions;
-            options.auth.user = profile.user;
-            options.auth.pass = profile.password;
+            options.auth.user = session.user;
+            options.auth.pass = session.password;
         }
         return new ZosConnect(options);
     }


### PR DESCRIPTION
Create a Session class which is used by the API layer and is created by the CLI layer from the IProfile to allow create flexibility of accessing z/OS Connect.