### PR TITLE
Display list output as table

### DIFF
--- a/src/cli/api/list/list.handler.ts
+++ b/src/cli/api/list/list.handler.ts
@@ -7,9 +7,11 @@ export default class ApiListHandler extends ZosConnectBaseHandler {
     public async processCmd(commandParameters: IHandlerParameters): Promise<void> {
         try {
             const apis = await ZosConnectApi.list(this.session);
-            for (const api of apis) {
-                commandParameters.response.console.log(`${api.name}(${api.version}) - ${api.description}`);
-            }
+            commandParameters.response.format.output({
+                fields: ["name", "version", "description"],
+                format: "table",
+                output: apis,
+            });
             commandParameters.response.data.setObj(apis);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/apirequester/list/list.handler.ts
+++ b/src/cli/apirequester/list/list.handler.ts
@@ -7,10 +7,11 @@ export default class ApiRequesterListHandler extends ZosConnectBaseHandler {
     public async processCmd(commandParameters: IHandlerParameters): Promise<void> {
         try {
             const apiRequesters = await ZosConnectApiRequester.list(this.session);
-            for (const apiRequester of apiRequesters) {
-                commandParameters.response.console.log(
-                    `${apiRequester.name}(${apiRequester.version}) - ${apiRequester.description}`);
-            }
+            commandParameters.response.format.output({
+                fields: ["name", "version", "description"],
+                format: "table",
+                output: apiRequesters,
+            });
             commandParameters.response.data.setObj(apiRequesters);
         } catch (error) {
             switch (error.constructor) {

--- a/src/cli/service/list/list.handler.ts
+++ b/src/cli/service/list/list.handler.ts
@@ -7,10 +7,11 @@ export default class ServiceListHandler extends ZosConnectBaseHandler {
     public async processCmd(commandParameters: IHandlerParameters): Promise<void> {
         try {
             const services = await ZosConnectService.list(this.session);
-            for (const service of services) {
-                commandParameters.response.console.log(`${service.name} - ${service.description} ` +
-                    `[${service.serviceProvider}]`);
-            }
+            commandParameters.response.format.output({
+                fields: ["name", "description", "serviceProvider"],
+                format: "table",
+                output: services,
+            });
             commandParameters.response.data.setObj(services);
         } catch (error) {
             switch (error.constructor) {


### PR DESCRIPTION
Use the format functionality in imperative to display the lists of artefacts as a table.