### PR TITLE
Handle when API Requester is not enabled

### DIFF
--- a/src/cli/apirequester/install/install.handler.ts
+++ b/src/cli/apirequester/install/install.handler.ts
@@ -43,6 +43,9 @@ export default class ApiRequsterInstallHandler extends ZosConnectBaseHandler {
                         case 403:
                             commandParameters.response.console.error("Security error, API Requster was not installed");
                             break;
+                        case 404:
+                            commandParameters.response.console.error("API Requester feature is not enabled");
+                            break;
                         case 409:
                             commandParameters.response.console.error(
                                 "Unable to install API Requester, one with the same name is already installed");

--- a/src/cli/apirequester/list/list.handler.ts
+++ b/src/cli/apirequester/list/list.handler.ts
@@ -34,6 +34,9 @@ export default class ApiRequesterListHandler extends ZosConnectBaseHandler {
                             commandParameters.response.console.error(
                                 "Security error, unable to display API Requesters");
                             break;
+                        case 404:
+                            commandParameters.response.console.error("API Requester feature is not enabled");
+                            break;
                         default:
                             commandParameters.response.console.error(statusCodeError.message);
                     }


### PR DESCRIPTION
Resolves #24

Add error handling for 404 on list and install which can
happen if the API Requester feature isn't installed.